### PR TITLE
[fix] Generalize variable stiffness interface

### DIFF
--- a/src/cartesian_admittance_controller.cpp
+++ b/src/cartesian_admittance_controller.cpp
@@ -788,60 +788,88 @@ void CartesianAdmittanceController::parse_target_wrench_() {
 
 void CartesianAdmittanceController::parse_target_stiffness_() {
   auto msg = *target_stiffness_buffer_.readFromRT();
-  if (msg->data.size() != 36) {
-    RCLCPP_WARN_THROTTLE(
-      get_node()->get_logger(),
-      *get_node()->get_clock(),
-      1000,
-      "Variable stiffness message must have exactly 36 elements (row-major 6x6), got %zu. Ignoring.",
-      msg->data.size());
-    return;
-  }
-  // Row-major 6x6 matrix
-  Eigen::Matrix<double, 6, 6> K =
-    Eigen::Map<const Eigen::Matrix<double, 6, 6, Eigen::RowMajor>>(msg->data.data());
-
-  // Enforce symmetry: a physical stiffness matrix must satisfy K == K^T.
-  // Reject the message entirely if the input is not symmetric within tolerance.
-  constexpr double kSymmetryTolerance = 1e-6;
-  const double max_asym = (K - K.transpose()).cwiseAbs().maxCoeff();
-  if (max_asym > kSymmetryTolerance) {
-    RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
-      "Topic impedance stiffness matrix not symmetric (max |K - K^T|=%.3g > %.1g), ignoring.",
-      max_asym, kSymmetryTolerance);
-    return;
-  }
-
-  // Clamp every entry. Diagonal must be non-negative; off-diagonals may be
-  // negative but are magnitude-bounded. Block bounds:
-  //   trans x trans -> max_k_trans
-  //   rot   x rot   -> max_k_rot
-  //   cross block   -> max_k_cross  (translational-rotational coupling)
-  // Bounds are symmetric in (i,j) / (j,i), so clamping preserves symmetry.
   const double max_k_trans = params_.variable_max_impedance_stiffness.translational;
   const double max_k_rot = params_.variable_max_impedance_stiffness.rotational;
-  const double max_k_cross = params_.variable_max_impedance_stiffness.cross;
-  for (int i = 0; i < 6; ++i) {
-    for (int j = 0; j < 6; ++j) {
-      const bool trans_block = (i < 3 && j < 3);
-      const bool rot_block = (i >= 3 && j >= 3);
-      const double max_val = trans_block ? max_k_trans
-                             : rot_block ? max_k_rot
-                                         : max_k_cross;
-      const double lo = (i == j) ? 0.0 : -max_val;
-      if (K(i, j) < lo || K(i, j) > max_val) {
+
+  // Back-compat path: 6-element diagonal stiffness (unchanged from main).
+  if (msg->data.size() == 6) {
+    std::array<double, 6> vals = {msg->data[0], msg->data[1], msg->data[2],
+                                  msg->data[3], msg->data[4], msg->data[5]};
+    for (int i = 0; i < 3; ++i) {
+      if (vals[i] < 0.0 || vals[i] > max_k_trans) {
         RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
-          "Topic impedance stiffness[%d,%d]=%.1f out of [%.1f, %.1f], clamping.",
-          i, j, K(i, j), lo, max_val);
-        K(i, j) = std::clamp(K(i, j), lo, max_val);
+          "Topic impedance stiffness[%d]=%.1f out of [0, %.1f], clamping.", i, vals[i], max_k_trans);
+        vals[i] = std::clamp(vals[i], 0.0, max_k_trans);
       }
     }
+    for (int i = 3; i < 6; ++i) {
+      if (vals[i] < 0.0 || vals[i] > max_k_rot) {
+        RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
+          "Topic impedance stiffness[%d]=%.1f out of [0, %.1f], clamping.", i, vals[i], max_k_rot);
+        vals[i] = std::clamp(vals[i], 0.0, max_k_rot);
+      }
+    }
+    topic_stiffness_.setZero();
+    topic_stiffness_.diagonal() << vals[0], vals[1], vals[2], vals[3], vals[4], vals[5];
+    use_topic_stiffness_ = true;
+    RCLCPP_INFO_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
+      "Variable impedance stiffness received: [%.1f, %.1f, %.1f, %.1f, %.1f, %.1f]",
+      vals[0], vals[1], vals[2], vals[3], vals[4], vals[5]);
+    return;
   }
-  topic_stiffness_ = K;
-  use_topic_stiffness_ = true;
-  RCLCPP_INFO_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
-    "Variable impedance stiffness received (6x6), diagonal: [%.1f, %.1f, %.1f, %.1f, %.1f, %.1f]",
-    K(0, 0), K(1, 1), K(2, 2), K(3, 3), K(4, 4), K(5, 5));
+
+  // Full 6x6 path: 36-element row-major matrix.
+  if (msg->data.size() == 36) {
+    Eigen::Matrix<double, 6, 6> K =
+      Eigen::Map<const Eigen::Matrix<double, 6, 6, Eigen::RowMajor>>(msg->data.data());
+
+    // Enforce symmetry: a physical stiffness matrix must satisfy K == K^T.
+    constexpr double kSymmetryTolerance = 1e-6;
+    const double max_asym = (K - K.transpose()).cwiseAbs().maxCoeff();
+    if (max_asym > kSymmetryTolerance) {
+      RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
+        "Topic impedance stiffness matrix not symmetric (max |K - K^T|=%.3g > %.1g), ignoring.",
+        max_asym, kSymmetryTolerance);
+      return;
+    }
+
+    // Clamp every entry. Diagonal must be non-negative; off-diagonals may be
+    // negative but are magnitude-bounded. Block bounds:
+    //   trans x trans -> max_k_trans
+    //   rot   x rot   -> max_k_rot
+    //   cross block   -> max_k_cross  (translational-rotational coupling)
+    // Bounds are symmetric in (i,j) / (j,i), so clamping preserves symmetry.
+    const double max_k_cross = params_.variable_max_impedance_stiffness.cross;
+    for (int i = 0; i < 6; ++i) {
+      for (int j = 0; j < 6; ++j) {
+        const bool trans_block = (i < 3 && j < 3);
+        const bool rot_block = (i >= 3 && j >= 3);
+        const double max_val = trans_block ? max_k_trans
+                               : rot_block ? max_k_rot
+                                           : max_k_cross;
+        const double lo = (i == j) ? 0.0 : -max_val;
+        if (K(i, j) < lo || K(i, j) > max_val) {
+          RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
+            "Topic impedance stiffness[%d,%d]=%.1f out of [%.1f, %.1f], clamping.",
+            i, j, K(i, j), lo, max_val);
+          K(i, j) = std::clamp(K(i, j), lo, max_val);
+        }
+      }
+    }
+    topic_stiffness_ = K;
+    use_topic_stiffness_ = true;
+    RCLCPP_INFO_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
+      "Variable impedance stiffness received (6x6), diagonal: [%.1f, %.1f, %.1f, %.1f, %.1f, %.1f]",
+      K(0, 0), K(1, 1), K(2, 2), K(3, 3), K(4, 4), K(5, 5));
+    return;
+  }
+
+  RCLCPP_WARN_THROTTLE(
+    get_node()->get_logger(),
+    *get_node()->get_clock(),
+    1000,
+    "Variable impedance stiffness message must have 6 (diagonal) or 36 (row-major 6x6) elements, got %zu. Ignoring.",
+    msg->data.size());
 }
 
 void CartesianAdmittanceController::parse_ft_sensor_() {
@@ -852,21 +880,51 @@ void CartesianAdmittanceController::parse_ft_sensor_() {
 
 void CartesianAdmittanceController::parse_target_adm_stiffness_() {
   auto msg = *target_adm_stiffness_buffer_.readFromRT();
+  const double max_ak_trans = params_.variable_max_admittance_stiffness.translational;
+  const double max_ak_rot = params_.variable_max_admittance_stiffness.rotational;
+
+  // Back-compat path: 6-element diagonal stiffness (unchanged from main).
+  if (msg->data.size() == 6) {
+    std::array<double, 6> avals = {msg->data[0], msg->data[1], msg->data[2],
+                                   msg->data[3], msg->data[4], msg->data[5]};
+    for (int i = 0; i < 3; ++i) {
+      if (avals[i] < 0.0 || avals[i] > max_ak_trans) {
+        RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
+          "Topic admittance stiffness[%d]=%.1f out of [0, %.1f], clamping.", i, avals[i], max_ak_trans);
+        avals[i] = std::clamp(avals[i], 0.0, max_ak_trans);
+      }
+    }
+    for (int i = 3; i < 6; ++i) {
+      if (avals[i] < 0.0 || avals[i] > max_ak_rot) {
+        RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
+          "Topic admittance stiffness[%d]=%.1f out of [0, %.1f], clamping.", i, avals[i], max_ak_rot);
+        avals[i] = std::clamp(avals[i], 0.0, max_ak_rot);
+      }
+    }
+    topic_adm_stiffness_.setZero();
+    topic_adm_stiffness_.diagonal() << avals[0], avals[1], avals[2], avals[3], avals[4], avals[5];
+    use_topic_adm_stiffness_ = true;
+    RCLCPP_INFO_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
+      "Variable admittance stiffness received: [%.1f, %.1f, %.1f, %.1f, %.1f, %.1f]",
+      avals[0], avals[1], avals[2], avals[3], avals[4], avals[5]);
+    return;
+  }
+
+  // Full 6x6 path: 36-element row-major matrix.
   if (msg->data.size() != 36) {
     RCLCPP_WARN_THROTTLE(
       get_node()->get_logger(),
       *get_node()->get_clock(),
       1000,
-      "Variable admittance stiffness must have 36 elements (row-major 6x6), got %zu. Ignoring.",
+      "Variable admittance stiffness must have 6 (diagonal) or 36 (row-major 6x6) elements, got %zu. Ignoring.",
       msg->data.size());
     return;
   }
-  // Row-major 6x6 matrix
+
   Eigen::Matrix<double, 6, 6> Ka =
     Eigen::Map<const Eigen::Matrix<double, 6, 6, Eigen::RowMajor>>(msg->data.data());
 
   // Enforce symmetry: a physical stiffness matrix must satisfy K == K^T.
-  // Reject the message entirely if the input is not symmetric within tolerance.
   constexpr double kSymmetryTolerance = 1e-6;
   const double max_asym = (Ka - Ka.transpose()).cwiseAbs().maxCoeff();
   if (max_asym > kSymmetryTolerance) {
@@ -882,8 +940,6 @@ void CartesianAdmittanceController::parse_target_adm_stiffness_() {
   //   rot   x rot   -> max_ak_rot
   //   cross block   -> max_ak_cross  (translational-rotational coupling)
   // Bounds are symmetric in (i,j) / (j,i), so clamping preserves symmetry.
-  const double max_ak_trans = params_.variable_max_admittance_stiffness.translational;
-  const double max_ak_rot = params_.variable_max_admittance_stiffness.rotational;
   const double max_ak_cross = params_.variable_max_admittance_stiffness.cross;
   for (int i = 0; i < 6; ++i) {
     for (int j = 0; j < 6; ++j) {

--- a/src/cartesian_admittance_controller.cpp
+++ b/src/cartesian_admittance_controller.cpp
@@ -694,7 +694,7 @@ void CartesianAdmittanceController::updateCurrentState(bool initialize) {
     auto joint_id = model_.getJointId(joint_name);
     auto joint = model_.joints[joint_id];
 
-#if HAS_LOANED_STATE_GET_OPTIONAL
+#if ROS2_VERSION_ABOVE_HUMBLE
     double q_meas = state_interfaces_[i].get_optional().value_or(q[i]);
     double dq_meas = state_interfaces_[num_joints + i].get_optional().value_or(dq[i]);
 #else
@@ -816,11 +816,11 @@ void CartesianAdmittanceController::parse_target_stiffness_() {
   // negative but are magnitude-bounded. Block bounds:
   //   trans x trans -> max_k_trans
   //   rot   x rot   -> max_k_rot
-  //   cross block   -> max(max_k_trans, max_k_rot)
+  //   cross block   -> max_k_cross  (translational-rotational coupling)
   // Bounds are symmetric in (i,j) / (j,i), so clamping preserves symmetry.
   const double max_k_trans = params_.variable_max_impedance_stiffness.translational;
   const double max_k_rot = params_.variable_max_impedance_stiffness.rotational;
-  const double max_k_cross = std::max(max_k_trans, max_k_rot);
+  const double max_k_cross = params_.variable_max_impedance_stiffness.cross;
   for (int i = 0; i < 6; ++i) {
     for (int j = 0; j < 6; ++j) {
       const bool trans_block = (i < 3 && j < 3);
@@ -880,12 +880,11 @@ void CartesianAdmittanceController::parse_target_adm_stiffness_() {
   // negative but are magnitude-bounded. Block bounds:
   //   trans x trans -> max_ak_trans
   //   rot   x rot   -> max_ak_rot
-  //   cross block   -> max(max_ak_trans, max_ak_rot)
-  // TODO: what bound to use for cross block values
+  //   cross block   -> max_ak_cross  (translational-rotational coupling)
   // Bounds are symmetric in (i,j) / (j,i), so clamping preserves symmetry.
   const double max_ak_trans = params_.variable_max_admittance_stiffness.translational;
   const double max_ak_rot = params_.variable_max_admittance_stiffness.rotational;
-  const double max_ak_cross = std::max(max_ak_trans, max_ak_rot);
+  const double max_ak_cross = params_.variable_max_admittance_stiffness.cross;
   for (int i = 0; i < 6; ++i) {
     for (int j = 0; j < 6; ++j) {
       const bool trans_block = (i < 3 && j < 3);

--- a/src/cartesian_admittance_controller.cpp
+++ b/src/cartesian_admittance_controller.cpp
@@ -694,7 +694,7 @@ void CartesianAdmittanceController::updateCurrentState(bool initialize) {
     auto joint_id = model_.getJointId(joint_name);
     auto joint = model_.joints[joint_id];
 
-#if ROS2_VERSION_ABOVE_HUMBLE
+#if HAS_LOANED_STATE_GET_OPTIONAL
     double q_meas = state_interfaces_[i].get_optional().value_or(q[i]);
     double dq_meas = state_interfaces_[num_joints + i].get_optional().value_or(dq[i]);
 #else
@@ -788,39 +788,60 @@ void CartesianAdmittanceController::parse_target_wrench_() {
 
 void CartesianAdmittanceController::parse_target_stiffness_() {
   auto msg = *target_stiffness_buffer_.readFromRT();
-  if (msg->data.size() != 6) {
+  if (msg->data.size() != 36) {
     RCLCPP_WARN_THROTTLE(
       get_node()->get_logger(),
       *get_node()->get_clock(),
       1000,
-      "Variable stiffness message must have exactly 6 elements, got %zu. Ignoring.",
+      "Variable stiffness message must have exactly 36 elements (row-major 6x6), got %zu. Ignoring.",
       msg->data.size());
     return;
   }
+  // Row-major 6x6 matrix
+  Eigen::Matrix<double, 6, 6> K =
+    Eigen::Map<const Eigen::Matrix<double, 6, 6, Eigen::RowMajor>>(msg->data.data());
+
+  // Enforce symmetry: a physical stiffness matrix must satisfy K == K^T.
+  // Reject the message entirely if the input is not symmetric within tolerance.
+  constexpr double kSymmetryTolerance = 1e-6;
+  const double max_asym = (K - K.transpose()).cwiseAbs().maxCoeff();
+  if (max_asym > kSymmetryTolerance) {
+    RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
+      "Topic impedance stiffness matrix not symmetric (max |K - K^T|=%.3g > %.1g), ignoring.",
+      max_asym, kSymmetryTolerance);
+    return;
+  }
+
+  // Clamp every entry. Diagonal must be non-negative; off-diagonals may be
+  // negative but are magnitude-bounded. Block bounds:
+  //   trans x trans -> max_k_trans
+  //   rot   x rot   -> max_k_rot
+  //   cross block   -> max(max_k_trans, max_k_rot)
+  // Bounds are symmetric in (i,j) / (j,i), so clamping preserves symmetry.
   const double max_k_trans = params_.variable_max_impedance_stiffness.translational;
   const double max_k_rot = params_.variable_max_impedance_stiffness.rotational;
-  std::array<double, 6> vals = {msg->data[0], msg->data[1], msg->data[2],
-                                msg->data[3], msg->data[4], msg->data[5]};
-  for (int i = 0; i < 3; ++i) {
-    if (vals[i] < 0.0 || vals[i] > max_k_trans) {
-      RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
-        "Topic impedance stiffness[%d]=%.1f out of [0, %.1f], clamping.", i, vals[i], max_k_trans);
-      vals[i] = std::clamp(vals[i], 0.0, max_k_trans);
+  const double max_k_cross = std::max(max_k_trans, max_k_rot);
+  for (int i = 0; i < 6; ++i) {
+    for (int j = 0; j < 6; ++j) {
+      const bool trans_block = (i < 3 && j < 3);
+      const bool rot_block = (i >= 3 && j >= 3);
+      const double max_val = trans_block ? max_k_trans
+                             : rot_block ? max_k_rot
+                                         : max_k_cross;
+      const double lo = (i == j) ? 0.0 : -max_val;
+      if (K(i, j) < lo || K(i, j) > max_val) {
+        RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
+          "Topic impedance stiffness[%d,%d]=%.1f out of [%.1f, %.1f], clamping.",
+          i, j, K(i, j), lo, max_val);
+        K(i, j) = std::clamp(K(i, j), lo, max_val);
+      }
     }
   }
-  for (int i = 3; i < 6; ++i) {
-    if (vals[i] < 0.0 || vals[i] > max_k_rot) {
-      RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
-        "Topic impedance stiffness[%d]=%.1f out of [0, %.1f], clamping.", i, vals[i], max_k_rot);
-      vals[i] = std::clamp(vals[i], 0.0, max_k_rot);
-    }
-  }
-  topic_stiffness_.setZero();
-  topic_stiffness_.diagonal() << vals[0], vals[1], vals[2], vals[3], vals[4], vals[5];
+  topic_stiffness_ = K;
   use_topic_stiffness_ = true;
   RCLCPP_INFO_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
-    "Variable impedance stiffness received: [%.1f, %.1f, %.1f, %.1f, %.1f, %.1f]",
-    vals[0], vals[1], vals[2], vals[3], vals[4], vals[5]);
+    "Variable impedance stiffness received (6x6), diagonal: [%.1f, %.1f, %.1f, %.1f, %.1f, %.1f]",
+    K(0, 0), K(1, 1), K(2, 2), K(3, 3), K(4, 4), K(5, 5));
 }
 
 void CartesianAdmittanceController::parse_ft_sensor_() {
@@ -831,39 +852,61 @@ void CartesianAdmittanceController::parse_ft_sensor_() {
 
 void CartesianAdmittanceController::parse_target_adm_stiffness_() {
   auto msg = *target_adm_stiffness_buffer_.readFromRT();
-  if (msg->data.size() != 6) {
+  if (msg->data.size() != 36) {
     RCLCPP_WARN_THROTTLE(
       get_node()->get_logger(),
       *get_node()->get_clock(),
       1000,
-      "Variable admittance stiffness must have 6 elements, got %zu. Ignoring.",
+      "Variable admittance stiffness must have 36 elements (row-major 6x6), got %zu. Ignoring.",
       msg->data.size());
     return;
   }
+  // Row-major 6x6 matrix
+  Eigen::Matrix<double, 6, 6> Ka =
+    Eigen::Map<const Eigen::Matrix<double, 6, 6, Eigen::RowMajor>>(msg->data.data());
+
+  // Enforce symmetry: a physical stiffness matrix must satisfy K == K^T.
+  // Reject the message entirely if the input is not symmetric within tolerance.
+  constexpr double kSymmetryTolerance = 1e-6;
+  const double max_asym = (Ka - Ka.transpose()).cwiseAbs().maxCoeff();
+  if (max_asym > kSymmetryTolerance) {
+    RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
+      "Topic admittance stiffness matrix not symmetric (max |K - K^T|=%.3g > %.1g), ignoring.",
+      max_asym, kSymmetryTolerance);
+    return;
+  }
+
+  // Clamp every entry. Diagonal must be non-negative; off-diagonals may be
+  // negative but are magnitude-bounded. Block bounds:
+  //   trans x trans -> max_ak_trans
+  //   rot   x rot   -> max_ak_rot
+  //   cross block   -> max(max_ak_trans, max_ak_rot)
+  // TODO: what bound to use for cross block values
+  // Bounds are symmetric in (i,j) / (j,i), so clamping preserves symmetry.
   const double max_ak_trans = params_.variable_max_admittance_stiffness.translational;
   const double max_ak_rot = params_.variable_max_admittance_stiffness.rotational;
-  std::array<double, 6> avals = {msg->data[0], msg->data[1], msg->data[2],
-                                 msg->data[3], msg->data[4], msg->data[5]};
-  for (int i = 0; i < 3; ++i) {
-    if (avals[i] < 0.0 || avals[i] > max_ak_trans) {
-      RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
-        "Topic admittance stiffness[%d]=%.1f out of [0, %.1f], clamping.", i, avals[i], max_ak_trans);
-      avals[i] = std::clamp(avals[i], 0.0, max_ak_trans);
+  const double max_ak_cross = std::max(max_ak_trans, max_ak_rot);
+  for (int i = 0; i < 6; ++i) {
+    for (int j = 0; j < 6; ++j) {
+      const bool trans_block = (i < 3 && j < 3);
+      const bool rot_block = (i >= 3 && j >= 3);
+      const double max_val = trans_block ? max_ak_trans
+                             : rot_block ? max_ak_rot
+                                         : max_ak_cross;
+      const double lo = (i == j) ? 0.0 : -max_val;
+      if (Ka(i, j) < lo || Ka(i, j) > max_val) {
+        RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
+          "Topic admittance stiffness[%d,%d]=%.1f out of [%.1f, %.1f], clamping.",
+          i, j, Ka(i, j), lo, max_val);
+        Ka(i, j) = std::clamp(Ka(i, j), lo, max_val);
+      }
     }
   }
-  for (int i = 3; i < 6; ++i) {
-    if (avals[i] < 0.0 || avals[i] > max_ak_rot) {
-      RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
-        "Topic admittance stiffness[%d]=%.1f out of [0, %.1f], clamping.", i, avals[i], max_ak_rot);
-      avals[i] = std::clamp(avals[i], 0.0, max_ak_rot);
-    }
-  }
-  topic_adm_stiffness_.setZero();
-  topic_adm_stiffness_.diagonal() << avals[0], avals[1], avals[2], avals[3], avals[4], avals[5];
+  topic_adm_stiffness_ = Ka;
   use_topic_adm_stiffness_ = true;
   RCLCPP_INFO_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
-    "Variable admittance stiffness received: [%.1f, %.1f, %.1f, %.1f, %.1f, %.1f]",
-    avals[0], avals[1], avals[2], avals[3], avals[4], avals[5]);
+    "Variable admittance stiffness received (6x6), diagonal: [%.1f, %.1f, %.1f, %.1f, %.1f, %.1f]",
+    Ka(0, 0), Ka(1, 1), Ka(2, 2), Ka(3, 3), Ka(4, 4), Ka(5, 5));
 }
 
 void CartesianAdmittanceController::log_debug_info(const rclcpp::Time & time) {

--- a/src/cartesian_admittance_controller.yaml
+++ b/src/cartesian_admittance_controller.yaml
@@ -326,6 +326,12 @@ cartesian_admittance_controller:
       description: "Maximum allowed rotational stiffness value. Stiffness values above this will be clamped."
       validation:
         bounds<>: [0.0, 100.0]
+    cross:
+      type: double
+      default_value: 500.0
+      description: "Maximum allowed magnitude for cross-coupling stiffness entries (translational-rotational off-diagonal blocks). Values above this will be clamped."
+      validation:
+        bounds<>: [0.0, 5000.0]
 
   variable_stiffness:
     enabled:
@@ -475,6 +481,12 @@ cartesian_admittance_controller:
       description: "Maximum allowed rotational admittance stiffness value. Values above this will be clamped."
       validation:
         bounds<>: [0.0, 100.0]
+    cross:
+      type: double
+      default_value: 100.0
+      description: "Maximum allowed magnitude for cross-coupling admittance stiffness entries (translational-rotational off-diagonal blocks). Values above this will be clamped."
+      validation:
+        bounds<>: [0.0, 5000.0]
 
   variable_admittance_stiffness:
     enabled:

--- a/src/cartesian_admittance_controller.yaml
+++ b/src/cartesian_admittance_controller.yaml
@@ -335,7 +335,7 @@ cartesian_admittance_controller:
     topic:
       type: string
       default_value: "target_stiffness"
-      description: "Topic name for receiving variable stiffness updates (std_msgs/Float64MultiArray with 6 elements: [k_pos_x, k_pos_y, k_pos_z, k_rot_x, k_rot_y, k_rot_z])"
+      description: "Topic name for receiving variable stiffness updates (std_msgs/Float64MultiArray with 36 elements representing a row-major 6x6 stiffness matrix)"
 
   enable_introspection:
     type: bool
@@ -484,4 +484,4 @@ cartesian_admittance_controller:
     topic:
       type: string
       default_value: "target_admittance_stiffness"
-      description: "Topic name for variable admittance stiffness (Float64MultiArray, 6 elements)"
+      description: "Topic name for variable admittance stiffness (Float64MultiArray, 36 elements representing a row-major 6x6 matrix)"

--- a/src/cartesian_admittance_controller.yaml
+++ b/src/cartesian_admittance_controller.yaml
@@ -341,7 +341,7 @@ cartesian_admittance_controller:
     topic:
       type: string
       default_value: "target_stiffness"
-      description: "Topic name for receiving variable stiffness updates (std_msgs/Float64MultiArray with 36 elements representing a row-major 6x6 stiffness matrix)"
+      description: "Topic name for receiving variable stiffness updates (std_msgs/Float64MultiArray with either 6 elements representing a diagonal stiffness or 36 elements representing a row-major 6x6 stiffness matrix)"
 
   enable_introspection:
     type: bool
@@ -496,4 +496,4 @@ cartesian_admittance_controller:
     topic:
       type: string
       default_value: "target_admittance_stiffness"
-      description: "Topic name for variable admittance stiffness (Float64MultiArray, 36 elements representing a row-major 6x6 matrix)"
+      description: "Topic name for variable admittance stiffness (Float64MultiArray with either 6 elements representing a diagonal stiffness or 36 elements representing a row-major 6x6 matrix)"

--- a/src/cartesian_controller.cpp
+++ b/src/cartesian_controller.cpp
@@ -615,39 +615,61 @@ void CartesianController::parse_target_wrench_() {
 
 void CartesianController::parse_target_stiffness_() {
   auto msg = *target_stiffness_buffer_.readFromRT();
-  if (msg->data.size() != 6) {
+  if (msg->data.size() != 36) {
     RCLCPP_WARN_THROTTLE(
       get_node()->get_logger(),
       *get_node()->get_clock(),
       1000,
-      "Variable stiffness message must have exactly 6 elements, got %zu. Ignoring.",
+      "Variable stiffness message must have exactly 36 elements (row-major 6x6), got %zu. Ignoring.",
       msg->data.size());
     return;
   }
+  // Row-major 6x6 matrix
+  Eigen::Matrix<double, 6, 6> K =
+    Eigen::Map<const Eigen::Matrix<double, 6, 6, Eigen::RowMajor>>(msg->data.data());
+
+  // Enforce symmetry: a physical stiffness matrix must satisfy K == K^T.
+  // Reject the message entirely if the input is not symmetric within tolerance.
+  constexpr double kSymmetryTolerance = 1e-6;
+  const double max_asym = (K - K.transpose()).cwiseAbs().maxCoeff();
+  if (max_asym > kSymmetryTolerance) {
+    RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
+      "Topic stiffness matrix not symmetric (max |K - K^T|=%.3g > %.1g), ignoring.",
+      max_asym, kSymmetryTolerance);
+    return;
+  }
+
+  // Clamp every entry. Diagonal must be non-negative; off-diagonals may be
+  // negative but are magnitude-bounded. Block bounds:
+  //   trans x trans -> max_k_trans
+  //   rot   x rot   -> max_k_rot
+  //   cross block   -> max(max_k_trans, max_k_rot)
+  // TODO: what bound to use for cross block values
+  // Bounds are symmetric in (i,j) / (j,i), so clamping preserves symmetry.
   const double max_k_trans = params_.variable_max_stiffness.translational;
   const double max_k_rot = params_.variable_max_stiffness.rotational;
-  std::array<double, 6> vals = {msg->data[0], msg->data[1], msg->data[2],
-                                msg->data[3], msg->data[4], msg->data[5]};
-  for (int i = 0; i < 3; ++i) {
-    if (vals[i] < 0.0 || vals[i] > max_k_trans) {
-      RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
-        "Topic stiffness[%d]=%.1f out of [0, %.1f], clamping.", i, vals[i], max_k_trans);
-      vals[i] = std::clamp(vals[i], 0.0, max_k_trans);
+  const double max_k_cross = std::max(max_k_trans, max_k_rot);
+  for (int i = 0; i < 6; ++i) {
+    for (int j = 0; j < 6; ++j) {
+      const bool trans_block = (i < 3 && j < 3);
+      const bool rot_block = (i >= 3 && j >= 3);
+      const double max_val = trans_block ? max_k_trans
+                             : rot_block ? max_k_rot
+                                         : max_k_cross;
+      const double lo = (i == j) ? 0.0 : -max_val;
+      if (K(i, j) < lo || K(i, j) > max_val) {
+        RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
+          "Topic stiffness[%d,%d]=%.1f out of [%.1f, %.1f], clamping.",
+          i, j, K(i, j), lo, max_val);
+        K(i, j) = std::clamp(K(i, j), lo, max_val);
+      }
     }
   }
-  for (int i = 3; i < 6; ++i) {
-    if (vals[i] < 0.0 || vals[i] > max_k_rot) {
-      RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
-        "Topic stiffness[%d]=%.1f out of [0, %.1f], clamping.", i, vals[i], max_k_rot);
-      vals[i] = std::clamp(vals[i], 0.0, max_k_rot);
-    }
-  }
-  topic_stiffness_.setZero();
-  topic_stiffness_.diagonal() << vals[0], vals[1], vals[2], vals[3], vals[4], vals[5];
+  topic_stiffness_ = K;
   use_topic_stiffness_ = true;
   RCLCPP_INFO_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
-    "Variable stiffness received: [%.1f, %.1f, %.1f, %.1f, %.1f, %.1f]",
-    vals[0], vals[1], vals[2], vals[3], vals[4], vals[5]);
+    "Variable stiffness received (6x6), diagonal: [%.1f, %.1f, %.1f, %.1f, %.1f, %.1f]",
+    K(0, 0), K(1, 1), K(2, 2), K(3, 3), K(4, 4), K(5, 5));
 }
 
 void CartesianController::log_debug_info(const rclcpp::Time & time) {

--- a/src/cartesian_controller.cpp
+++ b/src/cartesian_controller.cpp
@@ -615,60 +615,88 @@ void CartesianController::parse_target_wrench_() {
 
 void CartesianController::parse_target_stiffness_() {
   auto msg = *target_stiffness_buffer_.readFromRT();
-  if (msg->data.size() != 36) {
-    RCLCPP_WARN_THROTTLE(
-      get_node()->get_logger(),
-      *get_node()->get_clock(),
-      1000,
-      "Variable stiffness message must have exactly 36 elements (row-major 6x6), got %zu. Ignoring.",
-      msg->data.size());
-    return;
-  }
-  // Row-major 6x6 matrix
-  Eigen::Matrix<double, 6, 6> K =
-    Eigen::Map<const Eigen::Matrix<double, 6, 6, Eigen::RowMajor>>(msg->data.data());
-
-  // Enforce symmetry: a physical stiffness matrix must satisfy K == K^T.
-  // Reject the message entirely if the input is not symmetric within tolerance.
-  constexpr double kSymmetryTolerance = 1e-6;
-  const double max_asym = (K - K.transpose()).cwiseAbs().maxCoeff();
-  if (max_asym > kSymmetryTolerance) {
-    RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
-      "Topic stiffness matrix not symmetric (max |K - K^T|=%.3g > %.1g), ignoring.",
-      max_asym, kSymmetryTolerance);
-    return;
-  }
-
-  // Clamp every entry. Diagonal must be non-negative; off-diagonals may be
-  // negative but are magnitude-bounded. Block bounds:
-  //   trans x trans -> max_k_trans
-  //   rot   x rot   -> max_k_rot
-  //   cross block   -> max_k_cross  (translational-rotational coupling)
-  // Bounds are symmetric in (i,j) / (j,i), so clamping preserves symmetry.
   const double max_k_trans = params_.variable_max_stiffness.translational;
   const double max_k_rot = params_.variable_max_stiffness.rotational;
-  const double max_k_cross = params_.variable_max_stiffness.cross;
-  for (int i = 0; i < 6; ++i) {
-    for (int j = 0; j < 6; ++j) {
-      const bool trans_block = (i < 3 && j < 3);
-      const bool rot_block = (i >= 3 && j >= 3);
-      const double max_val = trans_block ? max_k_trans
-                             : rot_block ? max_k_rot
-                                         : max_k_cross;
-      const double lo = (i == j) ? 0.0 : -max_val;
-      if (K(i, j) < lo || K(i, j) > max_val) {
+
+  // Back-compat path: 6-element diagonal stiffness (unchanged from main).
+  if (msg->data.size() == 6) {
+    std::array<double, 6> vals = {msg->data[0], msg->data[1], msg->data[2],
+                                  msg->data[3], msg->data[4], msg->data[5]};
+    for (int i = 0; i < 3; ++i) {
+      if (vals[i] < 0.0 || vals[i] > max_k_trans) {
         RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
-          "Topic stiffness[%d,%d]=%.1f out of [%.1f, %.1f], clamping.",
-          i, j, K(i, j), lo, max_val);
-        K(i, j) = std::clamp(K(i, j), lo, max_val);
+          "Topic stiffness[%d]=%.1f out of [0, %.1f], clamping.", i, vals[i], max_k_trans);
+        vals[i] = std::clamp(vals[i], 0.0, max_k_trans);
       }
     }
+    for (int i = 3; i < 6; ++i) {
+      if (vals[i] < 0.0 || vals[i] > max_k_rot) {
+        RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
+          "Topic stiffness[%d]=%.1f out of [0, %.1f], clamping.", i, vals[i], max_k_rot);
+        vals[i] = std::clamp(vals[i], 0.0, max_k_rot);
+      }
+    }
+    topic_stiffness_.setZero();
+    topic_stiffness_.diagonal() << vals[0], vals[1], vals[2], vals[3], vals[4], vals[5];
+    use_topic_stiffness_ = true;
+    RCLCPP_INFO_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
+      "Variable stiffness received: [%.1f, %.1f, %.1f, %.1f, %.1f, %.1f]",
+      vals[0], vals[1], vals[2], vals[3], vals[4], vals[5]);
+    return;
   }
-  topic_stiffness_ = K;
-  use_topic_stiffness_ = true;
-  RCLCPP_INFO_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
-    "Variable stiffness received (6x6), diagonal: [%.1f, %.1f, %.1f, %.1f, %.1f, %.1f]",
-    K(0, 0), K(1, 1), K(2, 2), K(3, 3), K(4, 4), K(5, 5));
+
+  // Full 6x6 path: 36-element row-major matrix.
+  if (msg->data.size() == 36) {
+    Eigen::Matrix<double, 6, 6> K =
+      Eigen::Map<const Eigen::Matrix<double, 6, 6, Eigen::RowMajor>>(msg->data.data());
+
+    // Enforce symmetry: a physical stiffness matrix must satisfy K == K^T.
+    constexpr double kSymmetryTolerance = 1e-6;
+    const double max_asym = (K - K.transpose()).cwiseAbs().maxCoeff();
+    if (max_asym > kSymmetryTolerance) {
+      RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
+        "Topic stiffness matrix not symmetric (max |K - K^T|=%.3g > %.1g), ignoring.",
+        max_asym, kSymmetryTolerance);
+      return;
+    }
+
+    // Clamp every entry. Diagonal must be non-negative; off-diagonals may be
+    // negative but are magnitude-bounded. Block bounds:
+    //   trans x trans -> max_k_trans
+    //   rot   x rot   -> max_k_rot
+    //   cross block   -> max_k_cross  (translational-rotational coupling)
+    // Bounds are symmetric in (i,j) / (j,i), so clamping preserves symmetry.
+    const double max_k_cross = params_.variable_max_stiffness.cross;
+    for (int i = 0; i < 6; ++i) {
+      for (int j = 0; j < 6; ++j) {
+        const bool trans_block = (i < 3 && j < 3);
+        const bool rot_block = (i >= 3 && j >= 3);
+        const double max_val = trans_block ? max_k_trans
+                               : rot_block ? max_k_rot
+                                           : max_k_cross;
+        const double lo = (i == j) ? 0.0 : -max_val;
+        if (K(i, j) < lo || K(i, j) > max_val) {
+          RCLCPP_WARN_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
+            "Topic stiffness[%d,%d]=%.1f out of [%.1f, %.1f], clamping.",
+            i, j, K(i, j), lo, max_val);
+          K(i, j) = std::clamp(K(i, j), lo, max_val);
+        }
+      }
+    }
+    topic_stiffness_ = K;
+    use_topic_stiffness_ = true;
+    RCLCPP_INFO_THROTTLE(get_node()->get_logger(), *get_node()->get_clock(), 100,
+      "Variable stiffness received (6x6), diagonal: [%.1f, %.1f, %.1f, %.1f, %.1f, %.1f]",
+      K(0, 0), K(1, 1), K(2, 2), K(3, 3), K(4, 4), K(5, 5));
+    return;
+  }
+
+  RCLCPP_WARN_THROTTLE(
+    get_node()->get_logger(),
+    *get_node()->get_clock(),
+    1000,
+    "Variable stiffness message must have 6 (diagonal) or 36 (row-major 6x6) elements, got %zu. Ignoring.",
+    msg->data.size());
 }
 
 void CartesianController::log_debug_info(const rclcpp::Time & time) {

--- a/src/cartesian_controller.cpp
+++ b/src/cartesian_controller.cpp
@@ -643,12 +643,11 @@ void CartesianController::parse_target_stiffness_() {
   // negative but are magnitude-bounded. Block bounds:
   //   trans x trans -> max_k_trans
   //   rot   x rot   -> max_k_rot
-  //   cross block   -> max(max_k_trans, max_k_rot)
-  // TODO: what bound to use for cross block values
+  //   cross block   -> max_k_cross  (translational-rotational coupling)
   // Bounds are symmetric in (i,j) / (j,i), so clamping preserves symmetry.
   const double max_k_trans = params_.variable_max_stiffness.translational;
   const double max_k_rot = params_.variable_max_stiffness.rotational;
-  const double max_k_cross = std::max(max_k_trans, max_k_rot);
+  const double max_k_cross = params_.variable_max_stiffness.cross;
   for (int i = 0; i < 6; ++i) {
     for (int j = 0; j < 6; ++j) {
       const bool trans_block = (i < 3 && j < 3);

--- a/src/cartesian_controller.yaml
+++ b/src/cartesian_controller.yaml
@@ -341,7 +341,7 @@ cartesian_controller:
     topic:
       type: string
       default_value: "target_stiffness"
-      description: "Topic name for receiving variable stiffness updates (std_msgs/Float64MultiArray with 36 elements representing a row-major 6x6 stiffness matrix)"
+      description: "Topic name for receiving variable stiffness updates (std_msgs/Float64MultiArray with either 6 elements representing a diagonal stiffness or 36 elements representing a row-major 6x6 stiffness matrix)"
 
   enable_introspection:
     type: bool

--- a/src/cartesian_controller.yaml
+++ b/src/cartesian_controller.yaml
@@ -335,7 +335,7 @@ cartesian_controller:
     topic:
       type: string
       default_value: "target_stiffness"
-      description: "Topic name for receiving variable stiffness updates (std_msgs/Float64MultiArray with 6 elements: [k_pos_x, k_pos_y, k_pos_z, k_rot_x, k_rot_y, k_rot_z])"
+      description: "Topic name for receiving variable stiffness updates (std_msgs/Float64MultiArray with 36 elements representing a row-major 6x6 stiffness matrix)"
 
   enable_introspection:
     type: bool

--- a/src/cartesian_controller.yaml
+++ b/src/cartesian_controller.yaml
@@ -326,6 +326,12 @@ cartesian_controller:
       description: "Maximum allowed rotational stiffness value. Stiffness values above this will be clamped."
       validation:
         bounds<>: [0.0, 100.0]
+    cross:
+      type: double
+      default_value: 500.0
+      description: "Maximum allowed magnitude for cross-coupling stiffness entries (translational-rotational off-diagonal blocks). Values above this will be clamped."
+      validation:
+        bounds<>: [0.0, 5000.0]
 
   variable_stiffness:
     enabled:


### PR DESCRIPTION
# Variable stiffness: support full 6×6 matrix (back-compatible)

## Summary

During the use of the new feature, I quickly realised that exposing only the diagonal elements of the stiffness matrix is very limiting. This PR extends the variable stiffness topic interface in both `CartesianController` (impedance) and `CartesianAdmittanceController` to accept a full 6×6 matrix in addition to the existing 6-element diagonal form. Adds symmetry validation and per-block magnitude bounds for the new path.

## Topic protocol

`target_stiffness` and `target_admittance_stiffness` (`std_msgs/Float64MultiArray`) now accept either:

| Size | Interpretation | Validation |
| --- | --- | --- |
| **6** | Diagonal stiffness `[k_pos_x, k_pos_y, k_pos_z, k_rot_x, k_rot_y, k_rot_z]` (unchanged from main) | Per-axis clamp |
| **36** | Row-major 6×6 matrix | Symmetry check + per-block clamp |
| other | dropped with throttled warning | — |

## 6x6 checks & clamping

1. **Symmetry check** — reject if `max |K - K^T| > 1e-6` (logs the deviation and tolerance). Downstream code can assume `K` is symmetric.
2. **Per-element clamp** — every entry is clamped according to its block:

   |  | `j < 3` (trans) | `j ≥ 3` (rot) |
   | --- | --- | --- |
   | **`i < 3` (trans)** | `variable_max_*_stiffness.translational` | `variable_max_*_stiffness.cross` |
   | **`i ≥ 3` (rot)** | `variable_max_*_stiffness.cross` | `variable_max_*_stiffness.rotational` |

   - Diagonal entries clamped to `[0, max]` (stiffness must be non-negative).
   - Off-diagonals clamped to `[-max, max]` (coupling can be negative; magnitude bounded).
   - Bounds are symmetric in `(i,j)` / `(j,i)`, so clamping preserves the symmetry check.

## New YAML parameters

A single new `cross` field added to each existing stiffness-bound block. Defaults are conservative; existing diagonal-only configs are unaffected.

| Controller | Block | New param | Default |
| --- | --- | --- | --- |
| `cartesian_controller` | `variable_max_stiffness` | `.cross` | `500.0` |
| `cartesian_admittance_controller` | `variable_max_impedance_stiffness` | `.cross` | `500.0` |
| `cartesian_admittance_controller` | `variable_max_admittance_stiffness` | `.cross` | `100.0` |

All three accept the bound `[0, 5000]`.