### PR TITLE
feat: decouple translation from rotation in admittance MSD integration

### DIFF
--- a/src/cartesian_admittance_controller.cpp
+++ b/src/cartesian_admittance_controller.cpp
@@ -170,12 +170,19 @@ CartesianAdmittanceController::update(const rclcpp::Time & time, const rclcpp::D
   Eigen::Vector<double, 6> adm_force = ft_wrench_world - adm_damping_ * inner_motion_ + K_adm * adm_error;
   Eigen::Vector<double, 6> accel = adm_mass_inv_ * adm_force;
 
-  // 10. Semi-implicit Euler integration (translation and rotation integrated separately)
+  // 10. Semi-implicit Euler integration of the admittance target
   double dt = period.seconds();
   inner_motion_ += accel * dt;
-  inner_SE3_.translation() += inner_motion_.head(3) * dt;
-  inner_SE3_.rotation() =
-    (pinocchio::exp3(Eigen::Vector3d(inner_motion_.tail(3) * dt)) * inner_SE3_.rotation()).eval();
+  if (params_.coupled_se3_integration) {
+    // Legacy: exp6 left-multiply couples translation and rotation.
+    pinocchio::SE3 delta = pinocchio::exp6(pinocchio::Motion(inner_motion_ * dt));
+    inner_SE3_ = delta * inner_SE3_;
+  } else {
+    // Default: integrate translation (Euler) and rotation (exp3) independently.
+    inner_SE3_.translation() += inner_motion_.head(3) * dt;
+    inner_SE3_.rotation() =
+      (pinocchio::exp3(Eigen::Vector3d(inner_motion_.tail(3) * dt)) * inner_SE3_.rotation()).eval();
+  }
 
   // 11. Use inner_SE3_ as the desired for impedance outer loop
   // Compute impedance error (same as CartesianController but using inner_SE3_ as target)

--- a/src/cartesian_admittance_controller.cpp
+++ b/src/cartesian_admittance_controller.cpp
@@ -170,12 +170,12 @@ CartesianAdmittanceController::update(const rclcpp::Time & time, const rclcpp::D
   Eigen::Vector<double, 6> adm_force = ft_wrench_world - adm_damping_ * inner_motion_ + K_adm * adm_error;
   Eigen::Vector<double, 6> accel = adm_mass_inv_ * adm_force;
 
-  // 10. Semi-implicit Euler integration
+  // 10. Semi-implicit Euler integration (translation and rotation integrated separately)
   double dt = period.seconds();
   inner_motion_ += accel * dt;
-  // Update inner_SE3_ using exponential map
-  pinocchio::SE3 delta = pinocchio::exp6(pinocchio::Motion(inner_motion_ * dt));
-  inner_SE3_ = delta * inner_SE3_;
+  inner_SE3_.translation() += inner_motion_.head(3) * dt;
+  inner_SE3_.rotation() =
+    (pinocchio::exp3(Eigen::Vector3d(inner_motion_.tail(3) * dt)) * inner_SE3_.rotation()).eval();
 
   // 11. Use inner_SE3_ as the desired for impedance outer loop
   // Compute impedance error (same as CartesianController but using inner_SE3_ as target)

--- a/src/cartesian_admittance_controller.yaml
+++ b/src/cartesian_admittance_controller.yaml
@@ -194,6 +194,11 @@ cartesian_admittance_controller:
     default_value: false
     description: "If true, we use the local jacobian for computations, otherwise we use the world jacobian."
 
+  coupled_se3_integration:
+    type: bool
+    default_value: false
+    description: "If true, use legacy exp6 integration that couples translation and rotation. If false (default), integrate translation (Euler) and rotation (exp3) independently so a pure rotation spins in place."
+
   log:
     enabled:
       type: bool


### PR DESCRIPTION
## Fix: SE(3) integration bug causing arc swing on pure rotation commands

### Problem
Hello, commanding a pure end effector rotation using the CRISP Cartesian Admittance Controller caused the robot to swing sideways in an arc and return, rather than rotating in place. No translation was commanded, yet the EE position was being displaced.

### Root cause
I am not very familiar with `exp6` but the change fixed the problem. The admittance integration step updated the internal target pose with `exp6` and a left multiplication:

```cpp
pinocchio::SE3 delta = pinocchio::exp6(pinocchio::Motion(inner_motion_ * dt));
inner_SE3_ = delta * inner_SE3_;
```

Left multiplying applies `delta` in the world frame. For a pure angular velocity, `exp6` produces a rotation `R_delta` with zero translation, so the existing target position is rotated about the base origin:

```
t_new = R_delta * t_old
```

### Fix
Decouple the translation and rotation integration, matching the physically independent channels of the admittance MSD:

```cpp
inner_SE3_.translation() += inner_motion_.head(3) * dt;
inner_SE3_.rotation() =  (pinocchio::exp3(Eigen::Vector3d(inner_motion_.tail(3) * dt))   * inner_SE3_.rotation()).eval();
```

* Translation uses a plain world frame Euler step, zero if no translation is commanded.
* Rotation uses `exp3` (Rodrigues), which spins the orientation in place and never touches the position.
* The two channels stay independent, as the MSD model assumes.

### Testing
Validated on a UR5e.

Before:

https://github.com/user-attachments/assets/b9feddfd-b20d-43da-a290-a66c0963194d

After:

https://github.com/user-attachments/assets/8bef9317-e52e-471c-b3c5-9105f925c019




BTW @domrachev03 Did you face such problem ?