### PR TITLE
fix: Ensure CI runs on pull request events

### DIFF
--- a/.github/workflows/ros2_ci.yml
+++ b/.github/workflows/ros2_ci.yml
@@ -2,7 +2,9 @@
 # For troubleshooting, see README (https://github.com/ros-industrial/industrial_ci/blob/master/README.rst)
 name: ROS 2 CI
 
-on: [push]
+on:
+  push:
+  pull_request:
 
 jobs:
   industrial_ci:


### PR DESCRIPTION
Note that CI did not run on https://github.com/learnsyslab/crisp_controllers/pull/69, because the `push` event only works if you are working on the `learnsyslab` repo.

In my case from a fork, I needed to make these changes, which is more standard.